### PR TITLE
Add ChaosCamera

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,8 @@ The intention of this library is to make automatic testing possible without rely
 
 - `AnyCamera`: can hold any `cv::VideoCapture` interface compatible camera.
 
+- `MemoryCamera`: grabs images from a defined vector of images wich are already loaded in memory. Returns an empty image and error when the sequence was reached the end, or, when the `circular` option is enabled, starts from the start of the sequence again.
+
 - `FileCamera`: grabs images from a provided sequence of paths. Returns an empty image and error when the sequence was reached the end, or, when the `circular` option is enabled, starts from the start of the sequence again.
 
 - `DirectoryCamera` : grabs images from a provided directory. Returns an empty image anderror when the all images in the directory were shown once. When the `circular` option is enabled, the images in the directory are shown endlessly.

--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,26 @@ The intention of this library is to make automatic testing possible without rely
 
 - `HttpCamera` : opens a HTTP server where you can connect and can images (.png/.jpg) via "POST /images" \<body containing the encoded image data\>. Queues those images. "DELETE /images" empties the queue.
 
+### Camera Error Testing
+
+It is possible to control the error with a given camera. For this purpose, `ChaosCamera` exists. It takes a camera and a error controlling sequence, for example `RanomSequence` which has a change of throwing an exception based on randomness.
+
+Here is an example:
+```cpp
+AnyCamera camera = ...;
+ChaosCamera chaos_cam(std::move(camera), RandomSequence({.isOpen = {0.95}})); // isOpen will fail 95% of the time. It will throw the exception "NotOpenException".
+```
+
+You can also add custom exceptions and weight them
+```cpp
+AnyCamera camera = ...;
+ChaosCamera chaos_cam(std::move(camera), RandomSequence({.isOpen = RandomSequence::Fail(0.5).with<MyException>(5).with<MySecondException>(0.5) })); // "isOpen will fail 50% of the time, The ratio of MyException:MySecondException will be 10:1"
+```
+
+`ChaosCamera` supports `setExceptionMode` to enable/disable exceptions. It is on by default, so disable it if you don't want any. In this case, the corresponding functions will return `false`.
+
+All standard exception which will be thrown when no custom exceptions where defined, are derived from `std::exception`.
+
 ## Build Requirements
 
 - C++20
@@ -35,7 +55,7 @@ The intention of this library is to make automatic testing possible without rely
 
 ## How-To Use
 
-FairyCam provides a new class `AnyCamera` which is an interface of `cv::VideoCapture` without relying on inheritance. It
+FairyCam provides a new class `FairyCam::AnyCamera` which is an interface of `cv::VideoCapture` without relying on inheritance. It
  can take any Camera which fulfills the `cv::VideoCapture`/`FairyCam::IsAnyCamera`-Concept.
 
 An example using dynamic polymorphism where you can change the camera at runtime:

--- a/Readme.md
+++ b/Readme.md
@@ -64,10 +64,9 @@ int main()
     using namespace FairyCam;
     if (config::isTestingEnabled())
     {
-        auto opts = FileCamera::Options{.files={"myFile1.png""differentFile.jpg"}};
-        return startSystem(AnyCamera::create<FileCamera>(std::move(opts)));
+        return startSystem(FileCamera({.files={"myFile1.png", "differentFile.jpg"}));
     }
-    return startSystem(AnyCamera::create<cv::VideoCapture>());
+    return startSystem(cv::VideoCapture());
 }
 
 
@@ -103,7 +102,7 @@ int main()
     
     if (config::isTestingEnabled())
     {
-        return startSystem(FairyCamera::HttpCamera());
+        return startSystem(FileCamera({.files={"myFile1.png", "differentFile.jpg"}));
     }
     return startSystem(cv::VideoCapture());
 }

--- a/src/AnyCamera.hpp
+++ b/src/AnyCamera.hpp
@@ -122,6 +122,12 @@ class AnyCamera
     }
 
     template <IsAnyCamera CameraType>
+    static AnyCamera create(typename CameraType::Options opts)
+    {
+        return AnyCamera(std::make_unique<Model<CameraType>>(std::move(opts)));
+    }
+
+    template <IsAnyCamera CameraType>
     std::optional<std::reference_wrapper<CameraType>> dynamicCast() noexcept
     {
         auto modelPtr = dynamic_cast<Model<CameraType> *>(m_camera.get());

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,19 +1,28 @@
 find_package(OpenCV REQUIRED)
 find_package(Poco REQUIRED Foundation Net)
 
-add_library(FairyCam STATIC
-    HttpCamera.cpp
-    DirectoryTriggerCamera.cpp
-    FileCamera.cpp
-)
-
 set (HEADERS
     "AnyCamera.hpp"
+    "MemoryCamera.hpp"
     "FileCamera.hpp"
     "HttpCamera.hpp"
     "DirectoryCamera.hpp"
     "DirectoryTriggerCamera.hpp"
     "IsAnyCamera.hpp"
+
+    "chaos/ChaosCamera.hpp"
+    "chaos/Exceptions.hpp"
+    "chaos/Sequence.hpp"
+    "chaos/RandomSequence.hpp"
+)
+
+add_library(FairyCam STATIC
+    HttpCamera.cpp
+    DirectoryTriggerCamera.cpp
+    FileCamera.cpp
+    MemoryCamera.cpp
+
+    ${HEADERS}
 )
 
 target_sources(FairyCam PUBLIC FILE_SET HEADERS

--- a/src/MemoryCamera.cpp
+++ b/src/MemoryCamera.cpp
@@ -1,0 +1,43 @@
+#include "MemoryCamera.hpp"
+
+#include <opencv2/imgcodecs.hpp>
+
+namespace FairyCam
+{
+
+bool MemoryCamera::grab()
+{
+    if (!m_is_open)
+        return false;
+
+    m_current = m_next;
+    if (m_current == m_opts.images.cend())
+        return false;
+
+    ++m_next;
+    if (m_opts.circular && m_next == m_opts.images.cend())
+        m_next = m_opts.images.begin();
+
+    return !m_current->empty();
+}
+
+bool MemoryCamera::retrieve(cv::OutputArray image, int flag)
+{
+    if (!m_is_open || m_current == m_opts.images.cend())
+        return false;
+    cv::Mat mat = *m_current;
+    image.assign(mat);
+    return !mat.empty();
+}
+
+bool MemoryCamera::read(cv::OutputArray image)
+{
+    if (!grab())
+    {
+        image.assign(cv::Mat());
+        return false;
+    }
+    return retrieve(image);
+}
+
+} // namespace FairyCam

--- a/src/MemoryCamera.hpp
+++ b/src/MemoryCamera.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <filesystem>
+#include <opencv2/core.hpp>
+#include <vector>
+
+namespace FairyCam
+{
+
+class MemoryCamera
+{
+  public:
+    using ImageContainer = std::vector<cv::Mat>;
+    struct Options
+    {
+
+        ImageContainer images = {};
+        bool circular = false;
+    };
+
+  private:
+    Options m_opts;
+    bool m_is_open = false;
+    ImageContainer::const_iterator m_current;
+    ImageContainer::const_iterator m_next;
+
+  public:
+    MemoryCamera() : MemoryCamera(Options{}) {}
+    MemoryCamera(Options opts)
+        : m_opts{std::move(opts)}, m_current{m_opts.images.cend()},
+          m_next{m_opts.images.cend()}
+    {
+    }
+    bool open(int idx, int apiPreference, const std::vector<int> &params)
+    {
+        m_is_open = true;
+        m_next = m_opts.images.cbegin();
+        return true;
+    }
+    bool isOpened() const { return m_is_open; }
+    void release()
+    {
+        m_is_open = false;
+        m_current = m_opts.images.cend();
+        m_next = m_opts.images.cend();
+    }
+    bool grab();
+    bool retrieve(cv::OutputArray image, int flag = 0);
+    bool read(cv::OutputArray image);
+    bool set(int propId, double value) { return false; }
+    double get(int propId) const { return -1.0; }
+    void setExceptionMode(bool enable) {}
+    bool getExceptionMode() const { return false; }
+    MemoryCamera &operator>>(CV_OUT cv::Mat &image)
+    {
+        read(image);
+        return *this;
+    }
+    MemoryCamera &operator>>(CV_OUT cv::UMat &image)
+    {
+        read(image);
+        return *this;
+    }
+};
+
+} // namespace FairyCam

--- a/src/chaos/ChaosCamera.hpp
+++ b/src/chaos/ChaosCamera.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include "../AnyCamera.hpp"
+#include "Exceptions.hpp"
+#include "Sequence.hpp"
+#include <concepts>
+#include <memory>
+#include <opencv2/core.hpp>
+
+namespace FairyCam
+{
+
+class ChaosCamera
+{
+  private:
+    bool m_active_exception = true;
+    AnyCamera m_cam;
+    std::unique_ptr<Sequence> m_error_sequence;
+
+    bool checkIsOpen()
+    {
+        try
+        {
+            m_error_sequence->checkIsOpen();
+        }
+        catch (...)
+        {
+            this->release();
+            if (!m_active_exception)
+                return false;
+            throw;
+        }
+        return true;
+    }
+
+    bool checkGrab()
+    {
+        try
+        {
+            m_error_sequence->checkGrab();
+        }
+        catch (...)
+        {
+            if (!m_active_exception)
+                return false;
+            throw;
+        }
+        return true;
+    }
+
+    bool checkRetrieve()
+    {
+        try
+        {
+            m_error_sequence->checkRetrieve();
+        }
+        catch (...)
+        {
+            if (!m_active_exception)
+                return false;
+            throw;
+        }
+        return true;
+    }
+
+  public:
+    template <std::derived_from<Sequence> SeqT>
+    ChaosCamera(AnyCamera &&camera, SeqT seq)
+        : m_cam{std::move(camera)},
+          m_error_sequence{std::make_unique<SeqT>(std::move(seq))}
+    {
+    }
+    bool open(int idx, int apiPreference, const std::vector<int> &params)
+    {
+        if (!checkIsOpen())
+            return false;
+        return m_cam.open(idx, apiPreference, params);
+    }
+    bool isOpened() const
+    {
+        if (!const_cast<ChaosCamera *>(this)->checkIsOpen())
+            return false;
+        return m_cam.isOpened();
+    }
+    void release() { m_cam.release(); }
+    bool grab()
+    {
+        if (!isOpened())
+            return false;
+        if (!checkGrab())
+            return false;
+        if (!m_cam.grab())
+        {
+            if (m_active_exception)
+                throw GrabException{};
+            return false;
+        }
+        return true;
+    }
+    bool retrieve(cv::OutputArray image, int flag = 0)
+    {
+        if (!isOpened())
+            return false;
+        if (!checkRetrieve())
+            return false;
+        if (!m_cam.retrieve(image, flag))
+        {
+            if (m_active_exception)
+                throw RetrieveException{};
+            return false;
+        }
+        return true;
+    }
+    bool read(cv::OutputArray image)
+    {
+        if (!grab())
+            return false;
+        return retrieve(image);
+    }
+    bool set(int propId, double value) { return false; }
+    double get(int propId) const { return -1.0; }
+    void setExceptionMode(bool enable) noexcept { m_active_exception = enable; }
+    bool getExceptionMode() const noexcept { return m_active_exception; }
+    ChaosCamera &operator>>(CV_OUT cv::Mat &image)
+    {
+        read(image);
+        return *this;
+    }
+    ChaosCamera &operator>>(CV_OUT cv::UMat &image)
+    {
+        read(image);
+        return *this;
+    }
+};
+
+} // namespace FairyCam

--- a/src/chaos/Exceptions.hpp
+++ b/src/chaos/Exceptions.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <stdexcept>
+
+namespace FairyCam
+{
+
+class NotOpenException : public std::runtime_error
+{
+  public:
+    NotOpenException() : std::runtime_error{"FairyCam closed the camera."} {}
+};
+
+class RetrieveException : public std::runtime_error
+{
+  public:
+    RetrieveException() : std::runtime_error{"FairyCam error on retrieve."} {}
+};
+
+class GrabException : public std::runtime_error
+{
+  public:
+    GrabException() : std::runtime_error{"FairyCam error on grab."} {}
+};
+
+} // namespace FairyCam

--- a/src/chaos/RandomSequence.hpp
+++ b/src/chaos/RandomSequence.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <cassert>
+#include <concepts>
+#include <functional>
+#include <random>
+#include <thread>
+#include <vector>
+
+#include "Exceptions.hpp"
+#include "Sequence.hpp"
+
+namespace FairyCam
+{
+
+class RandomSequence : public Sequence
+{
+    struct Probas;
+
+  public:
+    class Fail
+    {
+        float probability;
+        std::vector<std::function<void()>> exceptions;
+        std::vector<double> weights;
+        friend Probas;
+
+      public:
+        Fail() : probability{0.f} {}
+        Fail(float probability) : probability{probability} {}
+
+        template <std::default_initializable ExceptionT>
+        Fail &with(double weight = 1.0)
+        {
+            return with([]() { throw ExceptionT{}; }, weight);
+        }
+        template <std::invocable<> Func> Fail &with(Func f, double weight = 1.0)
+        {
+            if (!f)
+                return *this;
+            exceptions.push_back(std::move(f));
+            weights.push_back(weight);
+            return *this;
+        }
+    };
+
+    struct Options
+    {
+        Fail isOpen = Fail{};
+        Fail grab = Fail{};
+        Fail retrieve = Fail{};
+    };
+
+    RandomSequence(Options opts)
+        : m_gen{std::random_device{}()}, m_is_open{std::move(opts.isOpen)},
+          m_retrieve{std::move(opts.retrieve)}, m_grab{std::move(opts.grab)}
+    {
+    }
+
+    RandomSequence(int seed, Options opts)
+        : m_is_open{std::move(opts.isOpen)},
+          m_retrieve{std::move(opts.retrieve)}, m_grab{std::move(opts.grab)}
+    {
+        m_gen.seed(seed);
+    }
+
+    void checkIsOpen() override { checkProba<NotOpenException>(m_is_open); }
+    void checkRetrieve() override { checkProba<RetrieveException>(m_retrieve); }
+    void checkGrab() override { checkProba<GrabException>(m_grab); }
+
+  private:
+    struct Probas
+    {
+        std::binomial_distribution<> fail;
+        std::discrete_distribution<> exception_distribution;
+        std::vector<std::function<void()>> exceptions;
+        Probas(Fail &&f)
+            : fail{std::binomial_distribution<>{1, f.probability}},
+              exception_distribution{std::begin(f.weights),
+                                     std::end(f.weights)},
+              exceptions{std::move(f.exceptions)}
+        {
+            assert(exceptions.size() == f.weights.size());
+        }
+    };
+
+    Probas m_is_open;
+    Probas m_retrieve;
+    Probas m_grab;
+    std::mt19937 m_gen;
+
+    template <std::default_initializable ExceptionT> void checkProba(Probas &p)
+    {
+        if (!p.fail(m_gen))
+            return;
+
+        if (p.exceptions.empty())
+            throw ExceptionT{};
+
+        auto idx = p.exception_distribution(m_gen);
+        std::invoke(p.exceptions[idx]);
+    }
+};
+
+} // namespace FairyCam

--- a/src/chaos/Sequence.hpp
+++ b/src/chaos/Sequence.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace FairyCam
+{
+class Sequence
+{
+  public:
+    virtual void checkIsOpen() = 0;
+    virtual void checkRetrieve() = 0;
+    virtual void checkGrab() = 0;
+    virtual ~Sequence() = default;
+};
+} // namespace FairyCam

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,9 @@ add_executable(Tests main.cpp
     HttpCamera.cpp
     AnyCamera.cpp
     DirectoryTriggerCamera.cpp
+    chaos/RandomSequence.cpp
+    chaos/ChaosCamera.cpp
+    MemoryCamera.cpp
 )
 
 target_include_directories(Tests PUBLIC ${OpenCV_INCLUDE_DIRS} )

--- a/tests/DirectoryCamera.cpp
+++ b/tests/DirectoryCamera.cpp
@@ -11,9 +11,8 @@ TEST_SUITE("DirectoryCamera")
         for (const bool circular : std::vector{false, true})
         {
             CAPTURE(circular);
-            AnyCamera cam =
-                AnyCamera::create<DirectoryCamera>(DirectoryCamera::Options{
-                    .dir = TEST_DATA, .circular = circular});
+            AnyCamera cam(
+                DirectoryCamera({.dir = TEST_DATA, .circular = circular}));
 
             REQUIRE(cam.open(0, 0, {}));
 
@@ -44,8 +43,7 @@ TEST_SUITE("DirectoryCamera")
                  "", TEST_DATA "/doesnotexists/", TEST_DATA "/test.png"})
         {
             CAPTURE(dir);
-            AnyCamera cam = AnyCamera::create<DirectoryCamera>(
-                DirectoryCamera::Options{.dir = dir});
+            AnyCamera cam(DirectoryCamera({.dir = dir}));
 
             REQUIRE_FALSE(cam.open(0, 0, {}));
             CHECK_FALSE(cam.isOpened());

--- a/tests/DirectoryTriggerCamera.cpp
+++ b/tests/DirectoryTriggerCamera.cpp
@@ -14,8 +14,7 @@ TEST_SUITE("DirectoryTriggerCamera")
 {
     TEST_CASE("invalid directory")
     {
-        AnyCamera cam = AnyCamera::create<DirectoryTriggerCamera>(
-            DirectoryTriggerCamera::Options{.dir = ""});
+        AnyCamera cam(AnyCamera::create<DirectoryTriggerCamera>({.dir = ""}));
 
         CHECK_FALSE(cam.open(0, 0, {}));
         CHECK_FALSE(cam.isOpened());
@@ -27,9 +26,8 @@ TEST_SUITE("DirectoryTriggerCamera")
 
     TEST_CASE("existing directory without new images")
     {
-        AnyCamera cam = AnyCamera::create<DirectoryTriggerCamera>(
-            DirectoryTriggerCamera::Options{.dir = TEST_DATA,
-                                            .grabTimeOutMs = 0});
+        AnyCamera cam(AnyCamera::create<DirectoryTriggerCamera>(
+            {.dir = TEST_DATA, .grabTimeOutMs = 0}));
 
         CHECK(cam.open(0, 0, {}));
         CHECK(cam.isOpened());
@@ -60,9 +58,8 @@ TEST_SUITE("DirectoryTriggerCamera")
             Remover cleanup{.dir = new_dir};
             REQUIRE(std::filesystem::create_directories(new_dir));
 
-            AnyCamera cam = AnyCamera::create<DirectoryTriggerCamera>(
-                DirectoryTriggerCamera::Options{.dir = new_dir,
-                                                .grabTimeOutMs = 50});
+            AnyCamera cam(AnyCamera::create<DirectoryTriggerCamera>(
+                {.dir = new_dir, .grabTimeOutMs = 50}));
 
             CHECK(cam.open(0, 0, {}));
             CHECK(cam.isOpened());

--- a/tests/HttpCamera.cpp
+++ b/tests/HttpCamera.cpp
@@ -53,8 +53,8 @@ TEST_SUITE("HttpCamera")
 {
     TEST_CASE("close and reopen")
     {
-        AnyCamera cam = AnyCamera::create<HttpCamera>(
-            HttpCamera::Options{.port = getPort(), .grabTimeOutMs = 0});
+        AnyCamera cam(AnyCamera::create<HttpCamera>(
+            {.port = getPort(), .grabTimeOutMs = 0}));
 
         REQUIRE(cam.open(0, 0, {}));
         REQUIRE(cam.isOpened());
@@ -72,10 +72,9 @@ TEST_SUITE("HttpCamera")
     TEST_CASE("release queue")
     {
         const auto port = getPort();
-        AnyCamera cam = AnyCamera::create<HttpCamera>(
-            HttpCamera::Options{.port = port, .grabTimeOutMs = 0});
-        Poco::Net::HTTPClientSession client =
-            Poco::Net::HTTPClientSession("127.0.0.1", port);
+        AnyCamera cam(
+            AnyCamera::create<HttpCamera>({.port = port, .grabTimeOutMs = 0}));
+        Poco::Net::HTTPClientSession client("127.0.0.1", port);
 
         REQUIRE(cam.open(0, 0, {}));
         REQUIRE(cam.isOpened());
@@ -96,10 +95,9 @@ TEST_SUITE("HttpCamera")
         {
             CAPTURE(n_images);
             const auto port = getPort();
-            AnyCamera cam = AnyCamera::create<HttpCamera>(
-                HttpCamera::Options{.port = port, .grabTimeOutMs = 0});
-            Poco::Net::HTTPClientSession client =
-                Poco::Net::HTTPClientSession("127.0.0.1", port);
+            AnyCamera cam(AnyCamera::create<HttpCamera>(
+                {.port = port, .grabTimeOutMs = 0}));
+            Poco::Net::HTTPClientSession client("127.0.0.1", port);
 
             REQUIRE(cam.open(0, 0, {}));
             REQUIRE(cam.isOpened());
@@ -125,10 +123,9 @@ TEST_SUITE("HttpCamera")
         {
             CAPTURE(n_images);
             const auto port = getPort();
-            AnyCamera cam = AnyCamera::create<HttpCamera>(
-                HttpCamera::Options{.port = port, .grabTimeOutMs = 0});
-            Poco::Net::HTTPClientSession client =
-                Poco::Net::HTTPClientSession("127.0.0.1", port);
+            AnyCamera cam(AnyCamera::create<HttpCamera>(
+                {.port = port, .grabTimeOutMs = 0}));
+            Poco::Net::HTTPClientSession client("127.0.0.1", port);
 
             REQUIRE(cam.open(0, 0, {}));
             REQUIRE(cam.isOpened());
@@ -151,10 +148,9 @@ TEST_SUITE("HttpCamera")
         {
             CAPTURE(n_images);
             const auto port = getPort();
-            AnyCamera cam = AnyCamera::create<HttpCamera>(
-                HttpCamera::Options{.port = port, .grabTimeOutMs = 0});
-            Poco::Net::HTTPClientSession client =
-                Poco::Net::HTTPClientSession("127.0.0.1", port);
+            AnyCamera cam(AnyCamera::create<HttpCamera>(
+                {.port = port, .grabTimeOutMs = 0}));
+            Poco::Net::HTTPClientSession client("127.0.0.1", port);
 
             REQUIRE(cam.open(0, 0, {}));
             REQUIRE(cam.isOpened());
@@ -185,10 +181,9 @@ TEST_SUITE("HttpCamera")
         {
             CAPTURE(n_images);
             const auto port = getPort();
-            AnyCamera cam = AnyCamera::create<HttpCamera>(
-                HttpCamera::Options{.port = port, .grabTimeOutMs = 0});
-            Poco::Net::HTTPClientSession client =
-                Poco::Net::HTTPClientSession("127.0.0.1", port);
+            AnyCamera cam(AnyCamera::create<HttpCamera>(
+                {.port = port, .grabTimeOutMs = 0}));
+            Poco::Net::HTTPClientSession client("127.0.0.1", port);
 
             REQUIRE(cam.open(0, 0, {}));
             REQUIRE(cam.isOpened());

--- a/tests/MemoryCamera.cpp
+++ b/tests/MemoryCamera.cpp
@@ -1,18 +1,19 @@
 #include <AnyCamera.hpp>
-#include <FileCamera.hpp>
+#include <MemoryCamera.hpp>
 #include <doctest.h>
+#include <opencv2/core.hpp>
 
 using namespace FairyCam;
 
-TEST_SUITE("FileCamera")
+TEST_SUITE("MemoryCamera")
 {
     TEST_CASE("load image")
     {
         for (const bool circular : std::vector{false, true})
         {
             CAPTURE(circular);
-            AnyCamera cam(FileCamera(
-                {.files = {TEST_DATA "test.png"}, .circular = circular}));
+            AnyCamera cam(MemoryCamera(
+                {.images = {cv::Mat(1, 1, CV_8UC1)}, .circular = circular}));
 
             REQUIRE(cam.open(0, 0, {}));
 
@@ -38,19 +39,13 @@ TEST_SUITE("FileCamera")
 
     TEST_CASE("load not existing image")
     {
-        for (auto images : std::vector{
-                 std::vector<std::string>(), std::vector<std::string>{""},
-                 std::vector<std::string>{TEST_DATA "doesnotexists.png"}})
-        {
-            CAPTURE(images);
-            AnyCamera cam(FileCamera({.files = std::move(images)}));
+        AnyCamera cam(MemoryCamera({.images = std::vector{cv::Mat()}}));
 
-            REQUIRE(cam.open(0, 0, {}));
-            CHECK(cam.isOpened());
-            cv::Mat m;
-            REQUIRE_FALSE(cam.read(m));
-            CHECK(m.empty());
-        }
+        REQUIRE(cam.open(0, 0, {}));
+        CHECK(cam.isOpened());
+        cv::Mat m;
+        REQUIRE_FALSE(cam.read(m));
+        CHECK(m.empty());
     }
 
     TEST_CASE("load multiple images")
@@ -58,9 +53,9 @@ TEST_SUITE("FileCamera")
         for (const bool circular : std::vector{false, true})
         {
             CAPTURE(circular);
-            AnyCamera cam(FileCamera(
-                {.files = {TEST_DATA "test.png", TEST_DATA "test.png",
-                           TEST_DATA "", TEST_DATA "test.png"},
+            AnyCamera cam(MemoryCamera(
+                {.images = {cv::Mat(1, 1, CV_8UC1), cv::Mat(1, 1, CV_8UC1),
+                            cv::Mat(), cv::Mat(1, 1, CV_8UC1)},
                  .circular = circular}));
 
             REQUIRE(cam.open(0, 0, {}));

--- a/tests/chaos/ChaosCamera.cpp
+++ b/tests/chaos/ChaosCamera.cpp
@@ -1,0 +1,111 @@
+#include <AnyCamera.hpp>
+#include <MemoryCamera.hpp>
+#include <chaos/ChaosCamera.hpp>
+#include <chaos/RandomSequence.hpp>
+#include <concepts>
+#include <doctest.h>
+
+using namespace FairyCam;
+
+TEST_SUITE("ChaosCamera")
+{
+    TEST_CASE("enabled exceptions")
+    {
+        // for (auto [failIsOpen, failGrab, failRetrieve] :
+        // std::views::cartesian_product(
+        //          std::array{0,1}, std::array{0,1}, std::array{0,1}))
+        for (auto [failIsOpen, failGrab, failRetrieve] : std::vector{
+                 std::array{0, 0, 0}, std::array{0, 0, 1}, std::array{0, 1, 0},
+                 std::array{0, 1, 1}, std::array{1, 0, 0}, std::array{1, 0, 1},
+                 std::array{1, 1, 0}, std::array{1, 1, 1}})
+        {
+            CAPTURE(failIsOpen);
+            CAPTURE(failGrab);
+            CAPTURE(failRetrieve);
+
+            float probaFailIsOpen = failIsOpen;
+            float probaFailGrab = failGrab;
+            float probaFailRetrieve = failRetrieve;
+
+            AnyCamera cam =
+                ChaosCamera(MemoryCamera({.images = {cv::Mat(1, 1, CV_8UC1)},
+                                          .circular = true}),
+                            RandomSequence({.isOpen = {probaFailIsOpen},
+                                            .grab = {probaFailGrab},
+                                            .retrieve = {probaFailRetrieve}}));
+            for (size_t i = 0; i < 10; ++i)
+            {
+                if (failIsOpen)
+                    REQUIRE_THROWS_AS(cam.open(0, 0, {}), NotOpenException);
+                else
+                    REQUIRE(cam.open(0, 0, {}));
+
+                if (failIsOpen)
+                    REQUIRE_THROWS_AS(cam.grab(), NotOpenException);
+                else if (failGrab)
+                    REQUIRE_THROWS_AS(cam.grab(), GrabException);
+                else
+                    REQUIRE(cam.grab());
+
+                cv::Mat mat;
+                if (failIsOpen)
+                    REQUIRE_THROWS_AS(cam.retrieve(mat), NotOpenException);
+                else if (failRetrieve || failGrab)
+                    REQUIRE_THROWS_AS(cam.retrieve(mat), RetrieveException);
+                else
+                    REQUIRE(cam.retrieve(mat));
+            }
+        }
+    }
+
+    TEST_CASE("disabled exceptions")
+    {
+        // for (auto [failIsOpen, failGrab, failRetrieve] :
+        // std::views::cartesian_product(
+        //          std::array{0,1}, std::array{0,1}, std::array{0,1}))
+        for (auto [failIsOpen, failGrab, failRetrieve] : std::vector{
+                 std::array{0, 0, 0}, std::array{0, 0, 1}, std::array{0, 1, 0},
+                 std::array{0, 1, 1}, std::array{1, 0, 0}, std::array{1, 0, 1},
+                 std::array{1, 1, 0}, std::array{1, 1, 1}})
+        {
+            CAPTURE(failIsOpen);
+            CAPTURE(failGrab);
+            CAPTURE(failRetrieve);
+
+            float probaFailIsOpen = failIsOpen;
+            float probaFailGrab = failGrab;
+            float probaFailRetrieve = failRetrieve;
+
+            AnyCamera cam =
+                ChaosCamera(MemoryCamera({.images = {cv::Mat(1, 1, CV_8UC1)},
+                                          .circular = true}),
+                            RandomSequence({.isOpen = {probaFailIsOpen},
+                                            .grab = {probaFailGrab},
+                                            .retrieve = {probaFailRetrieve}}));
+
+            cam.setExceptionMode(false);
+            for (size_t i = 0; i < 10; ++i)
+            {
+                if (failIsOpen)
+                    REQUIRE_FALSE(cam.open(0, 0, {}));
+                else
+                    REQUIRE(cam.open(0, 0, {}));
+
+                if (failIsOpen)
+                    REQUIRE_FALSE(cam.grab());
+                else if (failGrab)
+                    REQUIRE_FALSE(cam.grab());
+                else
+                    REQUIRE(cam.grab());
+
+                cv::Mat mat;
+                if (failIsOpen)
+                    REQUIRE_FALSE(cam.retrieve(mat));
+                else if (failRetrieve || failGrab)
+                    REQUIRE_FALSE(cam.retrieve(mat));
+                else
+                    REQUIRE(cam.retrieve(mat));
+            }
+        }
+    }
+}

--- a/tests/chaos/ChaosCamera.cpp
+++ b/tests/chaos/ChaosCamera.cpp
@@ -1,8 +1,11 @@
+#include <array>
+#include <concepts>
+#include <vector>
+
 #include <AnyCamera.hpp>
 #include <MemoryCamera.hpp>
 #include <chaos/ChaosCamera.hpp>
 #include <chaos/RandomSequence.hpp>
-#include <concepts>
 #include <doctest.h>
 
 using namespace FairyCam;

--- a/tests/chaos/RandomSequence.cpp
+++ b/tests/chaos/RandomSequence.cpp
@@ -1,6 +1,9 @@
-#include <chaos/RandomSequence.hpp>
+#include <array>
 #include <concepts>
 #include <doctest.h>
+#include <vector>
+
+#include <chaos/RandomSequence.hpp>
 
 using namespace FairyCam;
 

--- a/tests/chaos/RandomSequence.cpp
+++ b/tests/chaos/RandomSequence.cpp
@@ -1,0 +1,124 @@
+#include <chaos/RandomSequence.hpp>
+#include <concepts>
+#include <doctest.h>
+
+using namespace FairyCam;
+
+TEST_SUITE("RandomSequence")
+{
+    TEST_CASE("always or never")
+    {
+        // for (auto [failIsOpen, failGrab, failRetrieve] :
+        // std::views::cartesian_product(
+        //          std::array{0,1}, std::array{0,1}, std::array{0,1}))
+        for (auto [failIsOpen, failGrab, failRetrieve] : std::vector{
+                 std::array{0, 0, 0}, std::array{0, 0, 1}, std::array{0, 1, 0},
+                 std::array{0, 1, 1}, std::array{1, 0, 0}, std::array{1, 0, 1},
+                 std::array{1, 1, 0}, std::array{1, 1, 1}})
+        {
+            CAPTURE(failIsOpen);
+            CAPTURE(failGrab);
+            CAPTURE(failRetrieve);
+
+            RandomSequence s({.isOpen = RandomSequence::Fail(failIsOpen),
+                              .grab = RandomSequence::Fail(failGrab),
+                              .retrieve = RandomSequence::Fail(failRetrieve)});
+            for (size_t i = 0; i < 100; ++i)
+            {
+                if (failIsOpen)
+                    REQUIRE_THROWS_AS(s.checkIsOpen(), NotOpenException);
+                else
+                    s.checkIsOpen();
+
+                if (failGrab)
+                    REQUIRE_THROWS_AS(s.checkGrab(), GrabException);
+                else
+                    s.checkGrab();
+
+                if (failRetrieve)
+                    REQUIRE_THROWS_AS(s.checkRetrieve(), RetrieveException);
+                else
+                    s.checkRetrieve();
+            }
+        }
+    }
+
+    TEST_CASE("custom exceptions")
+    {
+        struct CustomException1
+        {
+        };
+
+        struct CustomException2
+        {
+        };
+
+        // for (auto [failIsOpen, failGrab, failRetrieve] :
+        // std::views::cartesian_product(
+        //          std::array{0,1}, std::array{0,1}, std::array{0,1}))
+
+        constexpr size_t runs = 1000;
+        for (auto [failIsOpen, failGrab, failRetrieve] : std::vector{
+                 std::array{0, 0, 0}, std::array{0, 0, 1}, std::array{0, 1, 0},
+                 std::array{0, 1, 1}, std::array{1, 0, 0}, std::array{1, 0, 1},
+                 std::array{1, 1, 0}, std::array{1, 1, 1}})
+        {
+            CAPTURE(failIsOpen);
+            CAPTURE(failGrab);
+            CAPTURE(failRetrieve);
+
+            RandomSequence s({.isOpen = RandomSequence::Fail(failIsOpen)
+                                            .with<CustomException1>()
+                                            .with<CustomException2>(),
+                              .grab = RandomSequence::Fail(failGrab)
+                                          .with<CustomException1>(0.0)
+                                          .with<CustomException2>(1.0),
+                              .retrieve = RandomSequence::Fail(failRetrieve)
+                                              .with<CustomException1>(1.0)
+                                              .with<CustomException2>(0.0)});
+
+            uint32_t threwCustom1 = 0;
+            uint32_t threwCustom2 = 0;
+            for (size_t i = 0; i < runs; ++i)
+            {
+                if (failIsOpen)
+                {
+                    try
+                    {
+                        s.checkIsOpen();
+                        FAIL("checkIsOpen did not throw any exception.");
+                    }
+                    catch (const CustomException1 &)
+                    {
+                        threwCustom1 += 1;
+                    }
+                    catch (const CustomException2 &)
+                    {
+                        threwCustom2 += 1;
+                    }
+                    catch (...)
+                    {
+                        FAIL("checkIsOpen did throw the wrong exception.");
+                    }
+                }
+
+                if (failGrab)
+                    REQUIRE_THROWS_AS(s.checkGrab(), CustomException2);
+                else
+                    s.checkGrab();
+
+                if (failRetrieve)
+                    REQUIRE_THROWS_AS(s.checkRetrieve(), CustomException1);
+                else
+                    s.checkRetrieve();
+            }
+
+            if (failIsOpen)
+            {
+                REQUIRE_EQ(threwCustom1 + threwCustom2, runs);
+                REQUIRE_GE(threwCustom1, runs * 0.35);
+                REQUIRE_GE(threwCustom2, runs * 0.35);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a proxy class, which behaves like a camera, but throws errors on a user specified sequence.

The sequqnces can be random, generated from a fuzz string (bytestring) or (optional).